### PR TITLE
Update package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1499,7 +1499,7 @@
         "hexo-i18n": "^0.2.1",
         "hexo-log": "^0.2.0",
         "hexo-util": "^0.6.3",
-        "js-yaml": "^3.6.1",
+        "js-yaml": ">=3.13.1",
         "lodash": "^4.17.5",
         "minimatch": "^3.0.4",
         "moment": "^2.19.4",
@@ -1684,7 +1684,7 @@
       "resolved": "https://registry.npmjs.org/hexo-front-matter/-/hexo-front-matter-0.2.3.tgz",
       "integrity": "sha1-x8qO9CDqNr2F6ECKLoyb9J76YF4=",
       "requires": {
-        "js-yaml": "^3.6.1"
+        "js-yaml": ">=3.13.1"
       }
     },
     "hexo-fs": {


### PR DESCRIPTION
Known moderate severity security vulnerability detected in js-yaml < 3.13.0 defined in package-lock.json. 

package-lock.json update suggested: js-yaml ~> 3.13.0. 
Always verify the validity and compatibility of suggestions with your codebase.